### PR TITLE
Implement setattr() to support changing file attributes

### DIFF
--- a/migrations/2020-06-18-184450_create_filesystem/up.sql
+++ b/migrations/2020-06-18-184450_create_filesystem/up.sql
@@ -4,6 +4,8 @@ CREATE TABLE filesystem (
     entry_type VARCHAR(9) CHECK(entry_type IN ('drive', 'file', 'directory')) NOT NULL DEFAULT 'file',
     created_at INTEGER NOT NULL,
     last_modified_at INTEGER NOT NULL,
+    last_accessed_at INTEGER NOT NULL,
+    mode INTEGER NOT NULL,
     remote_type VARCHAR CHECK(remote_type IN ('own_drive', 'team_drive', 'directory', 'file')),
     inode INTEGER NOT NULL,
     parent_id VARCHAR NULL,

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -43,6 +43,8 @@ pub struct FilesystemEntry {
     pub size: i64,
     pub parent_id: Option<String>,
     pub parent_inode: Option<i64>,
+    pub last_accessed_at: NaiveDateTime,
+    pub mode: i32,
 }
 
 #[derive(Clone)]
@@ -62,6 +64,30 @@ impl FilesystemRepository {
             .unwrap();
 
         largest_inode.unwrap_or(0)
+    }
+
+    pub(crate) fn update_mode_by_inode(&self, ino: i64, new_mode: i32) -> Result<usize> {
+        Ok(diesel::update(filesystem.filter(inode.eq(ino)))
+            .set(mode.eq(new_mode))
+            .execute(&self.connection.get().unwrap())?)
+    }
+
+    pub(crate) fn update_size_by_inode(&self, ino: i64, new_size: i64) -> Result<usize> {
+        Ok(diesel::update(filesystem.filter(inode.eq(ino)))
+            .set(size.eq(new_size))
+            .execute(&self.connection.get().unwrap())?)
+    }
+
+    pub(crate) fn update_last_access_by_inode(&self, ino: i64, access_time: NaiveDateTime) -> Result<usize> {
+        Ok(diesel::update(filesystem.filter(inode.eq(ino)))
+            .set(last_accessed_at.eq(access_time))
+            .execute(&self.connection.get().unwrap())?)
+    }
+
+    pub(crate) fn update_last_modification_by_inode(&self, ino: i64, modification_time: NaiveDateTime) -> Result<usize> {
+        Ok(diesel::update(filesystem.filter(inode.eq(ino)))
+            .set(last_modified_at.eq(modification_time))
+            .execute(&self.connection.get().unwrap())?)
     }
 
     pub(crate) fn transaction<T, E, F>(&self, f: F) -> Result<T, E>

--- a/src/database/schema.rs
+++ b/src/database/schema.rs
@@ -14,5 +14,7 @@ table! {
         size -> BigInt,
         parent_id -> Nullable<Text>,
         parent_inode -> Nullable<BigInt>,
+        last_accessed_at -> Timestamp,
+        mode -> Integer,
     }
 }

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -239,6 +239,8 @@ impl IndexWorker {
                         .parse()
                         .unwrap_or(0),
                     parent_inode,
+                    last_accessed_at: file.modified_time.naive_local(),
+                    mode: 0o700,
                 });
 
                 // but then, we also update all entries that have the current remote id as the parent remote
@@ -454,6 +456,8 @@ impl DriveIndex {
                         inode: self.repository.get_largest_inode() + 1,
                         size: 0,
                         parent_inode: Some(self.shared_drives_inode as i64),
+                        last_accessed_at: drive.created_time.naive_local(),
+                        mode: 0o700,
                     });
                 });
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,12 +150,14 @@ fn create_root(repository: &FilesystemRepository) -> u64 {
                 parent_id: None,
                 name: "StreamDrive".to_string(),
                 entry_type: EntryType::Directory,
-                created_at: date_time.clone(),
+                created_at: date_time,
                 last_modified_at: date_time,
                 remote_type: Some(RemoteType::Directory),
                 inode,
                 size: 0,
                 parent_inode: None,
+                last_accessed_at: date_time,
+                mode: 0o700,
             });
 
             inode as u64
@@ -180,6 +182,8 @@ fn create_shared_drives(repository: &FilesystemRepository, root_inode: u64) -> u
                 inode,
                 size: 0,
                 parent_inode: Some(root_inode as i64),
+                last_accessed_at: date_time,
+                mode: 0o700,
             });
 
             inode as u64
@@ -204,6 +208,8 @@ fn create_my_drives(repository: &FilesystemRepository, root_inode: u64) -> u64 {
                 inode,
                 size: 0,
                 parent_inode: Some(root_inode as i64),
+                last_accessed_at: date_time,
+                mode: 0o700,
             });
 
             inode as u64


### PR DESCRIPTION
This implementation is still pretty primitive. It doesn't update the attributes on Google's side and
it also only supports access time, modification time, size and mode. In case of any attribute change that
isn't supported, the function will just reply "OK" and swallow the change without actually changing anything.

We might implement ENOSYS in such cases, but it still needs some testing and figuring out whether that makes anything
better or even worse.

Closes #10