### PR TITLE
Implement mkdir()

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The basics. The application can index all **shared drives** you have access to. 
 * Create files
 * Delete files
 * Delete directories
+* Create directories
 * Write to files
 
 > ***Note:*** Writing to files only works as long as the files are written as a whole. Seeking and writing in the middle of files isn't supported. So it mostly depends on the application you are using to write those files.
@@ -52,7 +53,6 @@ The basics. The application can index all **shared drives** you have access to. 
 Biggest thing: performance. It's horrible. Really. In addition:
 
  * "My Drive"
- * Creating directories
  * Seeking in files/(re)writing only parts of a file
  * Local Caching
  * Graceful shutdown/unmounting

--- a/src/drive_client.rs
+++ b/src/drive_client.rs
@@ -75,6 +75,8 @@ pub struct FileCreateRequest {
     pub modified_time: DateTime<Utc>,
     pub name: String,
     pub parents: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -242,6 +242,7 @@ impl Filesystem for GdriveFs {
             modified_time: current_time,
             name: file_name.to_str().unwrap().to_string(),
             parents: vec![parent_directory.id],
+            mime_type: None,
         });
 
         match create_response {
@@ -321,7 +322,7 @@ impl Filesystem for GdriveFs {
             Ok(_) => {
                 let _ = self.repository.remove_entry_by_remote_id(entry.id.as_str());
                 reply.ok();
-            },
+            }
             Err(error) => {
                 log::error!("Failed to delete file [unlink()]: {:?}", error);
                 reply.error(libc::EIO);
@@ -478,6 +479,66 @@ impl Filesystem for GdriveFs {
         );
         println!("Our reply is {} long", data.len());
         reply.data(data.borrow());
+    }
+
+    fn mkdir(
+        &mut self,
+        _req: &Request<'_>,
+        parent_inode: u64,
+        file_name: &OsStr,
+        mode: u32,
+        reply: ReplyEntry,
+    ) {
+        let parent_directory = self.repository.find_entry_for_inode(parent_inode);
+
+        if parent_directory.is_none() {
+            reply.error(libc::ENOENT);
+            return;
+        }
+
+        let parent_directory = parent_directory.unwrap();
+        if parent_directory.entry_type == EntryType::File {
+            reply.error(libc::ENOTDIR);
+            return;
+        }
+
+        if self
+            .repository
+            .find_entry_as_child(parent_inode as i64, file_name)
+            .is_some()
+        {
+            reply.error(libc::EEXIST);
+            return;
+        }
+
+        let current_time = Utc::now();
+        let create_response = self.drive_client.create_file(FileCreateRequest {
+            created_time: current_time.clone(),
+            modified_time: current_time,
+            name: file_name.to_str().unwrap().to_string(),
+            parents: vec![parent_directory.id],
+            mime_type: Some("application/vnd.google-apps.folder".to_string()),
+        });
+
+        match create_response {
+            Ok(file) => {
+                // TODO: Improve error handling
+                let remote_id = file.id.clone();
+                IndexWriter::process_create_immediately(file, &self.repository);
+
+                let cache_entry = self
+                    .repository
+                    .find_entry_by_id(&remote_id)
+                    .expect("Freshly created entry is missing. That sucks.");
+                let attr = get_attr(&cache_entry);
+
+                reply.entry(&TTL, &attr, 1);
+            }
+            Err(err) => {
+                log::error!("Unexpected API error while creating a file: {:?}", err);
+                reply.error(libc::EIO);
+            }
+        }
     }
 
     /*fn statfs(&mut self, request: &Request, inode: u64, reply: ReplyStatfs) {

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -524,7 +524,9 @@ impl Filesystem for GdriveFs {
             Ok(file) => {
                 // TODO: Improve error handling
                 let remote_id = file.id.clone();
-                IndexWriter::process_create_immediately(file, &self.repository);
+                let new_inode = IndexWriter::process_create_immediately(file, &self.repository);
+
+                let _ = self.repository.update_mode_by_inode(new_inode, mode as i32);
 
                 let cache_entry = self
                     .repository

--- a/src/indexing.rs
+++ b/src/indexing.rs
@@ -56,8 +56,8 @@ impl IndexWriter {
         (self.worker.launch(), self.publisher)
     }
 
-    pub(crate) fn process_create_immediately(file: File, repository: &FilesystemRepository) {
-        IndexWorker::process_update(file, repository);
+    pub(crate) fn process_create_immediately(file: File, repository: &FilesystemRepository) -> i64 {
+        IndexWorker::process_update(file, repository)
     }
 }
 
@@ -312,7 +312,7 @@ impl IndexWorker {
             .expect("Unable to execute delete.");
     }
 
-    pub fn process_update(file: File, repository: &FilesystemRepository) {
+    pub fn process_update(file: File, repository: &FilesystemRepository) -> i64 {
         let remote_id = file.id;
         let parent_id = file.parents.first().map(|item| item.clone());
 
@@ -337,6 +337,8 @@ impl IndexWorker {
                     Ok(_) => (),
                     Err(err) => log::warn!("Unable to process update: {:?}", err),
                 }
+
+                inode
             }
             None => {
                 // First, we create the new entry itself
@@ -372,6 +374,8 @@ impl IndexWorker {
                 repository
                     .set_parent_inode_by_parent_id(&remote_id, inode)
                     .expect("Failed to update parent inodes");
+
+                    inode
             }
         }
     }


### PR DESCRIPTION
This PR adds functionality to create directories. They are instantly created on the Remote Drive and have the common sanity checks like not allowing creating directories inside of files or directories that already exist.