### PR TITLE
Build against better maintained fuse library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,25 +345,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuse"
-version = "0.4.0-dev"
+name = "fuser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74928cf021619b0612e45c3a5332e9a5302c6739b7b5eaecd835ba620c346e0d"
 dependencies = [
- "fuse-abi",
- "fuse-sys",
  "libc",
  "log",
- "thread-scoped",
-]
-
-[[package]]
-name = "fuse-abi"
-version = "0.4.0-dev"
-
-[[package]]
-name = "fuse-sys"
-version = "0.4.0-dev"
-dependencies = [
+ "page_size",
  "pkg-config",
+ "users",
 ]
 
 [[package]]
@@ -473,7 +464,7 @@ dependencies = [
  "diesel-derive-enum",
  "diesel_migrations",
  "dirs",
- "fuse",
+ "fuser",
  "futures",
  "hex",
  "hyper",
@@ -895,6 +886,16 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "page_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1412,12 +1413,6 @@ dependencies = [
  "remove_dir_all",
  "winapi",
 ]
-
-[[package]]
-name = "thread-scoped"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
 
 [[package]]
 name = "time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2.73"
 diesel = { version = "1.4.5", features = ["sqlite", "chrono", "r2d2"] }
 diesel-derive-enum = { version = "1", features = ["sqlite"] }
 diesel_migrations = "1.4.0"
-fuse = { path = "../fuse-rs" }
+fuser = "0.7.0"
 bytes = "1.0.0"
 log = "0.4"
 simple_logger = "1.11.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,7 @@ async fn main() -> Result<()> {
 
     let mount_path = config.general.mount_path.clone();
     let handle = tokio::task::spawn_blocking(|| {
-        fuse::mount(filesystem, mount_path, &[]).expect("unable to mount FUSE filesystem");
+        fuser::mount(filesystem, mount_path, &[]).expect("unable to mount FUSE filesystem");
     });
 
     let mut input = String::new();


### PR DESCRIPTION
Since zargony/fuse-rs is not really maintained anymore and is also missing some interesting features, we are switching to cberner/fuser instead. This patch adapts to the slightly different API.